### PR TITLE
Pull Request: add object reference to API Message

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -1,6 +1,6 @@
 # Fill in information about your library then remove # from the start of lines
 # https://docs.particle.io/guide/tools-and-features/libraries/#library-properties-fields
-name=RdWebServer
+name=RdWebServerObj
 version=1.0.17
 author=Rob Dobson
 license=MIT

--- a/src/RdWebServer.cpp
+++ b/src/RdWebServer.cpp
@@ -423,6 +423,9 @@ RdWebServerResourceDescr *RdWebClient::handleReceivedHttp(bool& handledOk, RdWeb
                                   argStr.c_str(), pHttpReq);
         apiMsg._pMsgContent   = _pHttpReqPayload;
         apiMsg._msgContentLen = _httpReqPayloadLen;
+        
+        apiMsg._objRef = pEndpoint->_objRef;
+        
         (pEndpoint->_callback)(apiMsg, retStr);
         Log.trace("WebClient#%d api response len %d",
                   _clientIdx, retStr.length());

--- a/src/RdWebServer.h
+++ b/src/RdWebServer.h
@@ -36,6 +36,7 @@ private:
     // TCP client
     TCPClient _TCPClient;
 
+public:
     // Methods
     static const int METHOD_OTHER   = 0;
     static const int METHOD_GET     = 1;

--- a/src/RestAPIEndpoints.h
+++ b/src/RestAPIEndpoints.h
@@ -12,6 +12,7 @@ struct RestAPIEndpointMsg
     const char* _pMsgHeader;
     unsigned char* _pMsgContent;
     int _msgContentLen;
+    void *_objRef;
     RestAPIEndpointMsg(int method, const char* pEndpointStr, const char* pArgStr, const char* pMsgHeader)
     {
         _method = method;
@@ -20,6 +21,7 @@ struct RestAPIEndpointMsg
         _pMsgHeader = pMsgHeader;
         _pMsgContent = NULL;
         _msgContentLen = 0;
+        _objRef = NULL;
     }
 };
 
@@ -41,13 +43,26 @@ public:
         _endpointStr = pStr;
         _endpointType = endpointType;
         _callback = callback;
+        _objRef = NULL;
         _contentType = pContentType;
         if (pContentEncoding)
             _contentEncoding = pContentEncoding;
         _noCache = noCache;
         if (pExtraHeaders)
             _extraHeaders = pExtraHeaders;
-    };
+    }
+
+    RestAPIEndpointDef(const char *pStr, int endpointType,
+                       RestAPIEndpointCallbackType callback,
+                       void *objRef,
+                       const char *pContentType,
+                       const char *pContentEncoding,
+                       bool noCache,
+                       const char *pExtraHeaders) : RestAPIEndpointDef(pStr, endpointType, callback, pContentType, pContentEncoding, noCache, pExtraHeaders)
+    {
+        _objRef = objRef;
+    }
+
     String _endpointStr;
     int _endpointType;
     String _contentType;
@@ -55,8 +70,12 @@ public:
     RestAPIEndpointCallbackType _callback;
     bool _noCache;
     String _extraHeaders;
+    void *_objRef;
 };
 
+
+                
+                
 // Collection of endpoints
 class RestAPIEndpoints
 {
@@ -109,6 +128,25 @@ public:
                 bool pNoCache = true,
                 const char* pExtraHeaders = NULL)
     {
+        addEndpointObj(pEndpointStr,
+            endpointType,
+            NULL,
+            callback,
+            pContentType,
+            pContentEncoding,
+            pNoCache,
+            pExtraHeaders
+        );
+    }
+
+    void addEndpointObj(const char *pEndpointStr, int endpointType,
+                void *objRef,
+                RestAPIEndpointCallbackType callback,
+                const char* pContentType,
+                const char* pContentEncoding,
+                bool pNoCache,
+                const char* pExtraHeaders)
+    {
         // Check for overflow
         if (_numEndpoints >= MAX_WEB_SERVER_ENDPOINTS)
         {
@@ -122,8 +160,8 @@ public:
                             pNoCache, pExtraHeaders);
         _pEndpoints[_numEndpoints] = pNewEndpointDef;
         _numEndpoints++;
-    }
 
+    }
 
     // Get the endpoint definition corresponding to a requested endpoint
     RestAPIEndpointDef *getEndpoint(const char *pEndpointStr)


### PR DESCRIPTION
The purpose of this request is to make callbacks a little bit friendlier for object encapsulation.  There are a few ways to approach this that would make a cleaner API.  I chose a simple way to do it, where you just register the callback with an object reference.  This still requires you to create a wrapper function (which includes an ugly but necessary cast).

A better approach would be to fully embrace OOP and do some tricks with templating.  That would take some time, though, and it would be difficult to do it without changing existing APIs.  This update only adds a second registration method, and doesn't change existing APIs at all.  I thought this to be a good compromise - it lets me do what I want (having instance methods as handlers) without touching too much code or breaking things.



  * Add  void *_objRef field to ApiMsg, defaulting to NULL
  * Add a new method addEndpointObj to RestAPIEndpoints
The new method is the same as the original addEndpointObj except that it
takes an objRef parameter.  The library doesn't do anything with this
parameter except that it gets passed back with the RestAPIEndpointMsg
when the callback is called.

The purpose of this is to allwo you to use object (instance) methods
as callbacks by adding a simple little wrapper.  In my case, I make the
wrapper a private static

private:
	void handlePost(RestAPIEndpointMsg &msg, String &retStr);
	static void handlePostWrapper(RestAPIEndpointMsg &msg,
		String &retStr);

the wrapper is a static method, which can be passed in as a function
pointer.  The wrapper is short and sweet:

void
GrafanaListener::handlePostWrapper(RestAPIEndpointMsg& apiMsg, String& retStr) {
    GrafanaListener *that = (GrafanaListener *) apiMsg._objRef;
    that->handlePost(apiMsg, retStr);

}

What all of this does is lets your callbacks reference other methods and
instance members of the enveloping class, approaching something more
a bit more object-oriented.